### PR TITLE
Make Logger refer to the correct source line

### DIFF
--- a/src/Game/Core/Data/Tween.ts
+++ b/src/Game/Core/Data/Tween.ts
@@ -1,5 +1,5 @@
 import * as TWEEN from '@tweenjs/tween.js';
-import Logger from '../../Logger';
+import Logger from '../Engine/Logger';
 
 class Tween {
   private _name: string; _easing: string; _object: any; _data: TWEEN.Tween | null;

--- a/src/Game/Core/Engine/AudioManager.ts
+++ b/src/Game/Core/Engine/AudioManager.ts
@@ -1,7 +1,7 @@
 import Loader from './Loader';
 import HwPlayer from '../../Services/Howler/HwPlayer';
 import Events from './Events';
-import Logger from '../../Logger';
+import Logger from './Logger';
 
 class AudioManager {
 

--- a/src/Game/Core/Engine/Events.ts
+++ b/src/Game/Core/Engine/Events.ts
@@ -1,4 +1,4 @@
-import Logger from "../../Logger";
+import Logger from "./Logger";
 
 class Events {
     private _events: any;

--- a/src/Game/Core/Engine/GameConfig.ts
+++ b/src/Game/Core/Engine/GameConfig.ts
@@ -1,4 +1,4 @@
-import Logger from "../../Logger";
+import Logger from "./Logger";
 
 class GameConfig {
   private _data: any;

--- a/src/Game/Core/Engine/GameObjects/Button.ts
+++ b/src/Game/Core/Engine/GameObjects/Button.ts
@@ -1,6 +1,6 @@
 import SpriteObject from "./SpriteObject";
 import IParentChild from "./IParentChild";
-import Logger from "../../../Logger";
+import Logger from "../Logger";
 
 
 

--- a/src/Game/Core/Engine/GameObjects/Camera.ts
+++ b/src/Game/Core/Engine/GameObjects/Camera.ts
@@ -6,7 +6,7 @@ import Geom from "../../Geom/Geom";
 import GameConfig from "../GameConfig";
 import InputManager from "../InputManager";
 import TweenComponent from "./Components/TweenComponent";
-import Logger from "../../../Logger";
+import Logger from "../Logger";
 
 class Camera {
     protected _math: MathUtils;

--- a/src/Game/Core/Engine/GameObjects/Components/FrameAnimationManager.ts
+++ b/src/Game/Core/Engine/GameObjects/Components/FrameAnimationManager.ts
@@ -4,7 +4,7 @@ import IGameObject from '../IGameObject';
 import IFrameAnimatedGameObject from '../IFrameAnimatedGameObject';
 import Loader from '../../Loader';
 import ObjectCore from './ObjectCore';
-import Logger from '../../../../Logger';
+import Logger from '../../Logger';
 
 
 class FrameAnimationManager implements IAnimationManager {

--- a/src/Game/Core/Engine/GameObjects/Components/ObjectCore.ts
+++ b/src/Game/Core/Engine/GameObjects/Components/ObjectCore.ts
@@ -14,7 +14,7 @@ import Mask from '../Mask';
 import SpineObject from '../SpineObject';
 import Loop from '../../Loop';
 import { RenderTexture } from 'pixi.js-legacy';
-import Logger from '../../../../Logger';
+import Logger from '../../Logger';
 
 
 class ObjectCore {

--- a/src/Game/Core/Engine/GameObjects/Components/ParentChildHandler.ts
+++ b/src/Game/Core/Engine/GameObjects/Components/ParentChildHandler.ts
@@ -2,7 +2,7 @@ import IParentChild from "../IParentChild";
 import IGameObject from '../IGameObject';
 import ObjectCore from './ObjectCore';
 import TextObject from "../TextObject";
-import Logger from "../../../../Logger";
+import Logger from "../../Logger";
 
 class ParentChildHandler implements IParentChild{
     private _parent: IGameObject | null = null;

--- a/src/Game/Core/Engine/GameObjects/Mask.ts
+++ b/src/Game/Core/Engine/GameObjects/Mask.ts
@@ -1,6 +1,6 @@
 import IObjectHandler from '../../../Services/IObjectHandler';
 import IScreen from '../../../Services/IScreen';
-import Logger from '../../../Logger';
+import Logger from '../Logger';
 
 
 class Mask {

--- a/src/Game/Core/Engine/GameObjects/SpineObject.ts
+++ b/src/Game/Core/Engine/GameObjects/SpineObject.ts
@@ -10,7 +10,7 @@ import AnimationManager from "./Components/FrameAnimationManager";
 import SpineAnimationManager from './Components/SpineAnimationManager';
 import Point from "../../Geom/Point";
 import TweenComponent from "./Components/TweenComponent";
-import Logger from "../../../Logger";
+import Logger from "../Logger";
 
 class SpineObject implements IGameObject {
     private _screen: IScreen;

--- a/src/Game/Core/Engine/GameObjects/TextObject.ts
+++ b/src/Game/Core/Engine/GameObjects/TextObject.ts
@@ -8,7 +8,7 @@ import InputHandler from "./Components/InputHandler";
 import ScaleHandler from "./Components/ScaleHandler";
 import Point from "../../Geom/Point";
 import TweenComponent from "./Components/TweenComponent";
-import Logger from "../../../Logger";
+import Logger from "../Logger";
 
 class TextObject implements IGameObject {
     private _screen: IScreen;

--- a/src/Game/Core/Engine/InputManager.ts
+++ b/src/Game/Core/Engine/InputManager.ts
@@ -6,7 +6,7 @@ import EventNames from "./EventNames";
 import ScaleManager from "./ScaleManager";
 import KeyCodes from './Keys';
 import KeyListener from "./KeyListener";
-import Logger from "../../Logger";
+import Logger from "./Logger";
 
 class InputManager {
     protected _pointFactory: Point;

--- a/src/Game/Core/Engine/Loader.ts
+++ b/src/Game/Core/Engine/Loader.ts
@@ -6,7 +6,7 @@ import AjaxLoader from '../../Services/AjaxLoader';
 import GameConfig from './GameConfig';
 import Loop from './Loop';
 import Events from './Events';
-import Logger from '../../Logger';
+import Logger from './Logger';
 
 class Loader {
   private _resource: Resource;

--- a/src/Game/Core/Engine/LogLevel.ts
+++ b/src/Game/Core/Engine/LogLevel.ts
@@ -1,0 +1,6 @@
+enum LogLevel {
+    ERROR,
+    WARNING,
+    INFO
+}
+export default LogLevel;

--- a/src/Game/Core/Engine/Logger.ts
+++ b/src/Game/Core/Engine/Logger.ts
@@ -1,8 +1,4 @@
-enum LogLevel {
-    ERROR,
-    WARNING,
-    INFO
-}
+import LogLevel from "./LogLevel";
 
 class Logger {
     private static _LEVELS = LogLevel;
@@ -11,26 +7,26 @@ class Logger {
     private static _level: number = LogLevel.INFO;
 
     private static _identifyLogSource(): string {
-        if (!this._source) {
+        if (!Logger._source) {
             let stack = Error().stack + '';
             let files = stack.match(/\w+\.ts|\w+\.js/g);
             files = (files) ? files : [];
 
-            if (files.length > 3) {
-                this._source = files[3];
+            if (files.length > 2) {
+                Logger._source = files[2];
             }
         }
 
-        let source = this._source;
-        this._source = '';
+        let source = Logger._source;
+        Logger._source = '';
         return source;
     }
 
     /**
      * @description Returns all levels this Logger can be set to
      */
-    public static get LEVELS(){
-        return this._LEVELS;
+    public static get LEVELS() {
+        return Logger._LEVELS;
     }
 
     /**
@@ -39,9 +35,9 @@ class Logger {
      * @returns Logger, to allow chain a print method after
      */
     public static source(source: string): Logger {
-        this._source = source;
+        Logger._source = source;
 
-        return this;
+        return Logger;
     }
 
     /**
@@ -49,48 +45,67 @@ class Logger {
      * @param level from the LogLevel enum, ERROR, WARNING or INFO
      */
     public static setLevel(level: number) {
-        this._level = level;
+        Logger._level = level;
+
+        Logger.info
     }
 
-    private static _log(consoleF: Function, ...args: any[]) {
-        let groupName = this._identifyLogSource();
-        if(groupName != this._previousSource) {
+    private static _setGroup() {
+        let groupName = Logger._identifyLogSource();
+        if (groupName != Logger._previousSource) {
             console.groupEnd();
             console.group(groupName);
-            this._previousSource = groupName;
+            Logger._previousSource = groupName;
         }
-        consoleF(...args);
     }
 
     /**
      * @description Logs a message in the browser console using console.log
      * @param args one or more arguments, any type
      */
-    public static info(...args: any[]) {
-        if (this._level >= LogLevel.INFO) {
-            this._log(console.log, ...args);
+    static get info() {
+        if (Logger._level >= LogLevel.INFO) {
+            Logger._setGroup();
+            return console.log.bind(console);
         }
+        return () => {};
     }
 
     /**
      * @description Logs a message in the browser console using console.error
      * @param args one or more arguments, any type
      */
-    public static error(...args: any[]) {
-        if (this._level >= LogLevel.ERROR) {
-            this._log(console.error, ...args);
+    static get error() {
+        if (Logger._level >= LogLevel.ERROR) {
+            Logger._setGroup();
+            return console.error.bind(console);
         }
-    }
+        return () => {};
+    };
 
     /**
      * @description Logs a message in the browser console using console.warn
      * @param args one or more arguments, any type
      */
-    public static warn(...args: any[]) {
-        if (this._level >= LogLevel.WARNING) {
-            this._log(console.warn, ...args);
+    static get warn() {
+        if (Logger._level >= LogLevel.WARNING) {
+            Logger._setGroup();
+            return console.warn.bind(console);
         }
-    }
+        return () => {};
+    };
+
+    /**
+     * @description Logs a message in the browser console using console.trace
+     * @param args one or more arguments, any type
+     */
+    static get trace() {
+        if (Logger._level >= LogLevel.INFO) {
+            Logger._setGroup();
+            return console.trace.bind(console);
+        }
+        return () => {};
+    };
 
     /**
      * @description The environment is development if the loglevel is higher that ERROR
@@ -106,7 +121,7 @@ class Logger {
      * @param label key to locate the object on the window
      */
     public static exposeGlobal(object: any, label: string) {
-        if(this.devEnvironment) {
+        if (Logger.devEnvironment) {
             (<any>window)[label] = object;
         }
     }
@@ -115,19 +130,19 @@ class Logger {
      * @description Call the debugging function (if available)
      */
     public static breakpoint() {
-        if(this.devEnvironment) {
+        if (Logger.devEnvironment) {
             debugger;
         }
     }
 
-    // From here onward all static methods are repeated as non-static ones.
-    // This is to allow its use in other projects by doing UAE.log...
+    // From here onward all static methods are repeated as non-static.
+    // This is to allow instantiation in the UAE API.
 
 
     /**
      * @description Returns all levels this Logger can be set to
      */
-    public get LEVELS(){
+    public get LEVELS() {
         return Logger.LEVELS;
     }
 
@@ -154,24 +169,32 @@ class Logger {
      * @description Logs a message in the browser console using console.log
      * @param args one or more arguments, any type
      */
-    public info(...args: any[]) {
-        Logger.info(...args);
-    }
+    get info() {
+        return Logger.info;
+    };
 
     /**
      * @description Logs a message in the browser console using console.error
      * @param args one or more arguments, any type
      */
-    public error(...args: any[]) {
-        Logger.error(...args);
-    }
+    get error() {
+        return Logger.error;
+    };
 
     /**
      * @description Logs a message in the browser console using console.warn
      * @param args one or more arguments, any type
      */
-    public warn(...args: any[]) {
-        Logger.warn(...args);
+    get warn() {
+        return Logger.warn;
+    };
+
+    /**
+     * @description Logs a message in the browser console using console.trace
+     * @param args one or more arguments, any type
+     */
+    get trace() {
+        return Logger.trace;
     }
 
     /**
@@ -195,9 +218,7 @@ class Logger {
      * @description Call the debugging function (if available)
      */
     public breakpoint() {
-        if(this.devEnvironment) {
-            debugger;
-        }
+        Logger.breakpoint();
     }
 }
 

--- a/src/Game/Core/Engine/Loop.ts
+++ b/src/Game/Core/Engine/Loop.ts
@@ -1,6 +1,6 @@
 import Events from '../Engine/Events';
 import FunObj from '../Data/FunObj';
-import Logger from '../../Logger';
+import Logger from './Logger';
 
 class Loop {
   private _funObj: FunObj;

--- a/src/Game/Core/Engine/ScriptHandler.ts
+++ b/src/Game/Core/Engine/ScriptHandler.ts
@@ -1,6 +1,6 @@
 import ActScripts from './Utils/ActScripts';
 import Events from './Events';
-import Logger from '../../Logger';
+import Logger from './Logger';
 
 class ScriptHandler {
     private _utils: ActScripts;

--- a/src/Game/Core/Engine/TransitionManager.ts
+++ b/src/Game/Core/Engine/TransitionManager.ts
@@ -6,7 +6,7 @@ import transitions from "./Transitions";
 import IScreen from "../../Services/IScreen";
 import Events from "./Events";
 import GOFactory from "./GameObjects/GOFactory";
-import Logger from "../../Logger";
+import Logger from "./Logger";
 
 class TransitionManager {
     private _tweens: TweenManager; private _screen: IScreen; private _events: Events; private _goFactory: GOFactory;

--- a/src/Game/Core/Engine/TweenManager.ts
+++ b/src/Game/Core/Engine/TweenManager.ts
@@ -1,6 +1,6 @@
 import Tween from "../Data/Tween";
 import Easing from './GameObjects/Components/Easing';
-import Logger from "../../Logger";
+import Logger from "./Logger";
 import Loop from "./Loop";
 
 class TweenManager {

--- a/src/Game/Core/Engine/Utils/ArrayHandler.ts
+++ b/src/Game/Core/Engine/Utils/ArrayHandler.ts
@@ -1,4 +1,4 @@
-import Logger from "../../../Logger";
+import Logger from "../Logger";
 
 class ArrayHandler {
   constructor() {

--- a/src/Game/Core/Engine/Utils/Collections.ts
+++ b/src/Game/Core/Engine/Utils/Collections.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import Logger from '../../../Logger';
+import Logger from '../Logger';
 
 class Collections {
 

--- a/src/Game/Core/Engine/Utils/Text.ts
+++ b/src/Game/Core/Engine/Utils/Text.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import Logger from '../../../Logger';
+import Logger from '../Logger';
 
 class Text {
 

--- a/src/Game/Core/Game.ts
+++ b/src/Game/Core/Game.ts
@@ -14,7 +14,7 @@ import IScene from './Engine/IScene';
 import ILevel from './Engine/ILevel';
 import Transitions from '../Core/Engine/Transitions';
 import TweenManager from './Engine/TweenManager';
-import Logger from '../Logger';
+import Logger from './Engine/Logger';
 
 class Game {
   private _world: World; _events: Events;

--- a/src/Game/Services/Howler/HwPlayer.ts
+++ b/src/Game/Services/Howler/HwPlayer.ts
@@ -1,7 +1,7 @@
 import Loader from '../../Core/Engine/Loader';
 import { Howl } from 'howler';
 import Resource from '../../Core/Data/Resource';
-import Logger from '../../Logger';
+import Logger from '../../Core/Engine/Logger';
 
 class HwPlayer {
     private _loader: Loader;

--- a/src/Game/Services/Pixi/PxFactory.ts
+++ b/src/Game/Services/Pixi/PxFactory.ts
@@ -1,7 +1,7 @@
 import { Application, Loader, Sprite, Renderer, Container, NineSlicePlane, Point, Texture, RenderTexture, DisplayObject } from 'pixi.js-legacy';
 import * as PIXI from 'pixi.js-legacy';
 import PxText from './PxText';
-import Logger from '../../Logger';
+import Logger from '../../Core/Engine/Logger';
 
 class PxFactory {
   private _pxText: PxText;

--- a/src/Game/Services/Pixi/PxGame.ts
+++ b/src/Game/Services/Pixi/PxGame.ts
@@ -5,7 +5,7 @@ import Loader from '../../Core/Engine/Loader';
 import 'pixi-spine';
 import Events from '../../Core/Engine/Events';
 import GameConfig from '../../Core/Engine/GameConfig';
-import Logger from '../../Logger';
+import Logger from '../../Core/Engine/Logger';
 
 class PxGame {
   private _pxFactory: PxFactory; _loader: Loader; _events: Events;

--- a/src/Game/Services/Pixi/PxLoader.ts
+++ b/src/Game/Services/Pixi/PxLoader.ts
@@ -2,7 +2,7 @@ import { Loader } from 'pixi.js-legacy';
 import 'pixi-spine';
 
 import PxFactory from './PxFactory';
-import Logger from '../../Logger';
+import Logger from '../../Core/Engine/Logger';
 
 class PxLoader {
   private _pxFactory: PxFactory;;

--- a/src/Game/Services/Pixi/PxText.ts
+++ b/src/Game/Services/Pixi/PxText.ts
@@ -1,7 +1,7 @@
 import PxPoint from './PxPoint';
 
 import {Text, Sprite, Renderer, SCALE_MODES} from 'pixi.js-legacy';
-import Logger from '../../Logger';
+import Logger from '../../Core/Engine/Logger';
 
 class PxText {
   private _pxPoint: PxPoint;

--- a/src/Game/Services/Screen.ts
+++ b/src/Game/Services/Screen.ts
@@ -1,5 +1,5 @@
 import { Application, Sprite, DisplayObject, Texture, RenderTexture } from 'pixi.js-legacy';
-import Logger from '../Logger';
+import Logger from '../Core/Engine/Logger';
 
 import IScreen from '../Services/IScreen';
 import PxGame from '../Services/Pixi/PxGame';

--- a/src/Game/Services/SndLoader.ts
+++ b/src/Game/Services/SndLoader.ts
@@ -1,6 +1,6 @@
 import ISndLoader from './ISndLoader';
 import HwLoader from './Howler/HwLoader';
-import Logger from '../Logger';
+import Logger from '../Core/Engine/Logger';
 
 class SndLoader implements ISndLoader {
     private _loader: HwLoader;

--- a/src/Game/UAE.ts
+++ b/src/Game/UAE.ts
@@ -10,7 +10,7 @@ import Geom from './Core/Geom/Geom';
 import Utils from './Core/Engine/Utils/Utils';
 import Transitions from './Core/Engine/Transitions';
 import TweenManager from './Core/Engine/TweenManager';
-import Logger from './Logger';
+import Logger from './Core/Engine/Logger';
 
 /**
  * @description The UAEngine API. 


### PR DESCRIPTION
Several changes: 
- Use console.[function].bind(console) to point to the real line of code and not the Logger line.
- Added trace method
- Moved Logger back to Core/Engine.