### PR TITLE
When objectifying a cell, convert to number if appropriate

### DIFF
--- a/src/Game/Core/Engine/Utils/Text.ts
+++ b/src/Game/Core/Engine/Utils/Text.ts
@@ -48,7 +48,8 @@ class Text {
 
             let vals = sublines[1].trim().split(valueSeperator);
             if (vals.length <= 1) {
-                obj[sublines[0]] = vals[0]
+                let asNumber: number = Number(vals[0]);
+                obj[sublines[0]] = (isNaN(asNumber)) ? vals[0]: asNumber;
             }
             else {
                 obj[sublines[0]] = vals;


### PR DESCRIPTION
This one would be useful when getting dragzones, as they won't need to be converted.

I may be missing something here, so feel free to reject it if need be. This can be done in different places.