### PR TITLE
ParentChildHandler.addChild() not setting _parent

### DIFF
--- a/src/Game/Core/Engine/GameObjects/Components/ParentChildHandler.ts
+++ b/src/Game/Core/Engine/GameObjects/Components/ParentChildHandler.ts
@@ -30,13 +30,9 @@ class ParentChildHandler implements IParentChild{
     }
 
     set parent(parent: IGameObject | null) {
-        if(parent !== null){
-            if(this._parent){this._parent.removeChild(this._go)}
+        if(parent !== null) {
+            parent.addChild(this._go);
             this._parent = parent;
-            if(this._parent){
-                if(!this._parent.hasChild(this._go)) this._parent.addChild(this._go); // addChild if it isn't already one
-            }
-          //  this._go.scaleHandler.onResize();
         }
     }
 
@@ -63,9 +59,9 @@ class ParentChildHandler implements IParentChild{
         if (!this.hasChild(object)) {
             if(object.parent && object.parent !== this._go) {
                 object.parent.removeChild(object);
-                object.parent = this._go;
             }
             this._children.push(object);
+            object.parent = this._go;
 
             // added this condition because text objects hold their Px data 1 level deeper, due to custom PxText class
             let child: IGameObject = object.data.data ? object.data.data : object.data;


### PR DESCRIPTION
When the parent was null or undefined, it was not set.
`_children.push()` moved above `this._parent = parent` to avoid infinite loop.
Also simplified `set parent()` as what it did is also done in `addChild()`.