### PR TITLE
Parse Level File

### DIFF
--- a/src/Game/Core/Engine/Activities/BaseLevel.ts
+++ b/src/Game/Core/Engine/Activities/BaseLevel.ts
@@ -66,6 +66,11 @@ abstract class BaseLevel extends BaseScene implements ILevel {
         this._loader.loadActScript(scriptName, (script: any, data: any) => {
             if (data == null || data == undefined) Debug.error('no script data returned: ', data);
             this.manager.init(scriptName, script, parseCols, objectifyCols, processText);
+            if(script[0].hasOwnProperty('config') && script[0].config.includes('level_file:')) {
+                this._loader.loadLevelFile(scriptName, (script: any) => {
+                    this.manager.setLevelFile(script);
+                });
+            }
             this.preload();
         });
     }

--- a/src/Game/Core/Engine/LevelManager.ts
+++ b/src/Game/Core/Engine/LevelManager.ts
@@ -39,6 +39,14 @@ class LevelManager {
         this._script.init(scriptName, scriptRaw, parseCols, objectifyCols, processText);
     }
 
+    /**
+     * @description Passes on the Level file content to the Level Manager.
+     * @param content Level file content
+     */
+    setLevelFile(content: any) {
+        this._script.levelFile = content;
+    }
+
     get events(): Events {
         return this._events;
     }

--- a/src/Game/Core/Engine/Loader.ts
+++ b/src/Game/Core/Engine/Loader.ts
@@ -533,6 +533,17 @@ class Loader {
     });
   }
 
+  loadLevelFile(file: string, callback?: Function, staticPath: boolean = false) {
+    let basePath = '';
+    if (!staticPath) basePath = this._getPath().jsn;
+
+    this._ajaxLoader.loadFile(basePath + file + '_level.json', (data: any) => {
+      if (callback !== undefined) {
+        callback(data.data);
+      }
+    });
+  }
+
   private _downloadSpines() {
     let spineList = this._getSpnArray(this._newResList);
     Debug.info('spines to load:');

--- a/src/Game/Core/Engine/ScriptHandler.ts
+++ b/src/Game/Core/Engine/ScriptHandler.ts
@@ -14,6 +14,7 @@ class ScriptHandler {
     private _rows: any[];
     private _active: any;
     private _last: any;
+    private _levelFile: any;
 
     constructor(utils: ActScripts, events: Events) {
         this._utils = utils;
@@ -54,6 +55,10 @@ class ScriptHandler {
         if(list.length > 0) Debug.error('these columns do not exist in script: ', list);
     }
 
+    get levelFile(): any {
+        return this._levelFile;
+    }
+
     get name(): string {
         return this._name;
     }
@@ -75,6 +80,10 @@ class ScriptHandler {
      */
     get active(): any {
         return this._active;
+    }
+
+    set levelFile(content: any) {
+        this._levelFile = content;
     }
 
     /**


### PR DESCRIPTION
Load level file if the activity script has a level_file property in the config.
BaseLevel triggers the check, Loader gets the file content and ScriptHandler stores it.