### PR TITLE
BaseLevel character: Use addAnimation() instead of play()

### DIFF
--- a/src/Game/Core/Engine/Activities/BaseLevel.ts
+++ b/src/Game/Core/Engine/Activities/BaseLevel.ts
@@ -163,7 +163,7 @@ abstract class BaseLevel extends BaseScene implements ILevel {
             let animation = this.activeRow.char;
             if (animation && animation !== '') this._character.animations.addAnimation(animation, loop);
             if (this._character.animations.animationNames.includes('idle')) {
-                this._character.animations.addAnimation('idle', true);
+                if (!loop) this._character.animations.addAnimation('idle', true);
             } else {
                 Debug.error('Character %s has no "idle" animation', this._character.name);
             }


### PR DESCRIPTION
This way animations are not cut when moving through script rows.
It will also play 'idle' in loop if the animation before is to be played only once.