### PR TITLE
BaseLevel character: config won't be present in some rows

### DIFF
--- a/src/Game/Core/Engine/Activities/BaseLevel.ts
+++ b/src/Game/Core/Engine/Activities/BaseLevel.ts
@@ -168,6 +168,7 @@ abstract class BaseLevel extends BaseScene implements ILevel {
             if (!char) { // Default position and scale if char is not on Level file
                 char = { x: 20, y: this._game.height() - 150, scaleX: 1 };
             }
+            if(this._character) this._character.destroy();
             this._character = this._goFactory.spine(char.x, char.y, this.activeRow.config.char, this._foreground);
             this._character.scaleHandler.scale = char.scaleX;
             Debug.exposeGlobal(this._character, 'char');


### PR DESCRIPTION
Also added a guard just in case: if the character exists, destroy() it.